### PR TITLE
Removes the `mixed` param type declaration

### DIFF
--- a/src/TimeInterval.php
+++ b/src/TimeInterval.php
@@ -18,7 +18,7 @@ class TimeInterval
         int $intervalLength,
         string $leadingData  = null,
         string $trailingData = null,
-        mixed $interval
+        $interval
     )
     {
         $this->interval = $interval;


### PR DESCRIPTION
Mixed isn't a type and resulted in:

> Fatal error: Uncaught TypeError: Argument 5 passed to IntervalParser\TimeInterval::__construct() must be an instance of IntervalParser\mixed, instance of DateInterval given
