### PR TITLE
Added TimeInterval and ParserSettings tests

### DIFF
--- a/tests/IntervalParserTests/ParserSettingsTest.php
+++ b/tests/IntervalParserTests/ParserSettingsTest.php
@@ -1,0 +1,135 @@
+<?php declare(strict_types = 1);
+
+namespace IntervalParserTests;
+
+use IntervalParser\ParserSettings;
+use PHPUnit\Framework\TestCase;
+
+class ParserSettingsTest extends TestCase
+{
+    public function testGetLeadingSeparatorWhenManuallySet()
+    {
+        $parserSettings = new ParserSettings('foo');
+
+        $this->assertSame('foo', $parserSettings->getLeadingSeparator());
+    }
+
+    public function testGetLeadingSeparatorWhenUsingTheDefault()
+    {
+        $parserSettings = new ParserSettings();
+
+        $this->assertSame('in', $parserSettings->getLeadingSeparator());
+    }
+
+    public function testGetSymbolSeparatorWhenManuallySet()
+    {
+        $parserSettings = new ParserSettings('foo', false, ParserSettings::SYMBOL, ';');
+
+        $this->assertSame(';', $parserSettings->getSymbolSeparator());
+    }
+
+    public function testGetSymbolSeparatorWhenUsingTheDefault()
+    {
+        $parserSettings = new ParserSettings();
+
+        $this->assertSame(',', $parserSettings->getSymbolSeparator());
+    }
+
+    public function testGetWordSeparatorWhenManuallySet()
+    {
+        $parserSettings = new ParserSettings('foo', false, ParserSettings::SYMBOL, ';', 'bar');
+
+        $this->assertSame('bar', $parserSettings->getWordSeparator());
+    }
+
+    public function testGetWordSeparatorWhenUsingTheDefault()
+    {
+        $parserSettings = new ParserSettings();
+
+        $this->assertSame(',', $parserSettings->getWordSeparator());
+    }
+
+    public function testKeepLeadingSeparatorWhenManuallySetToTrue()
+    {
+        $parserSettings = new ParserSettings('foo', true);
+
+        $this->assertTrue($parserSettings->keepLeadingSeparator());
+    }
+
+    public function testKeepLeadingSeparatorWhenManuallySetToFalse()
+    {
+        $parserSettings = new ParserSettings('foo', false);
+
+        $this->assertFalse($parserSettings->keepLeadingSeparator());
+    }
+
+    public function testKeepLeadingSeparatorWhenUsingTheDefault()
+    {
+        $parserSettings = new ParserSettings();
+
+        $this->assertFalse($parserSettings->keepLeadingSeparator());
+    }
+
+    public function testGetSeparationTypeWhenManuallySetToSymbol()
+    {
+        $parserSettings = new ParserSettings('foo', true, ParserSettings::SYMBOL);
+
+        $this->assertSame('symbol', $parserSettings->getSeparationType());
+    }
+
+    public function testGetSeparationTypeWhenManuallySetToString()
+    {
+        $parserSettings = new ParserSettings('foo', false, ParserSettings::STRING);
+
+        $this->assertSame('string', $parserSettings->getSeparationType());
+    }
+
+    public function testGetSeparationTypeWhenUsingTheDefault()
+    {
+        $parserSettings = new ParserSettings();
+
+        $this->assertSame('symbol', $parserSettings->getSeparationType());
+    }
+
+    public function testGetLeadingSeparatorExpressionWhenManuallySet()
+    {
+        $parserSettings = new ParserSettings('foo');
+
+        $this->assertSame('/(.*)\s+(?:foo)\s+(.*)/ui', $parserSettings->getLeadingSeparatorExpression());
+    }
+
+    public function testGetLeadingSeparatorExpressionWhenUsingTheDefault()
+    {
+        $parserSettings = new ParserSettings();
+
+        $this->assertSame('/(.*)\s+(?:in)\s+(.*)/ui', $parserSettings->getLeadingSeparatorExpression());
+    }
+
+    public function testGetSymbolSeparatorExpressionWhenManuallySet()
+    {
+        $parserSettings = new ParserSettings('foo', false, ParserSettings::SYMBOL, ';');
+
+        $this->assertSame('/(?<first>[^;]*)\s?;\s?(?<next>.*)$/ui', $parserSettings->getSymbolSeparatorExpression());
+    }
+
+    public function testGetSymbolSeparatorExpressionWhenUsingTheDefault()
+    {
+        $parserSettings = new ParserSettings();
+
+        $this->assertSame('/(?<first>[^,]*)\s?,\s?(?<next>.*)$/ui', $parserSettings->getSymbolSeparatorExpression());
+    }
+
+    public function testGetWordSeparatorExpressionWhenManuallySet()
+    {
+        $parserSettings = new ParserSettings('in', false, ParserSettings::SYMBOL, ',', 'bar');
+
+        $this->assertSame('/^(?<first>.*?)\s?bar\s?(?<next>.*)$/ui', $parserSettings->getWordSeparatorExpression());
+    }
+
+    public function testGetWordSeparatorExpressionWhenUsingTheDefault()
+    {
+        $parserSettings = new ParserSettings();
+
+        $this->assertSame('/^(?<first>.*?)\s?word\s?(?<next>.*)$/ui', $parserSettings->getWordSeparatorExpression());
+    }
+}

--- a/tests/IntervalParserTests/TimeIntervalTest.php
+++ b/tests/IntervalParserTests/TimeIntervalTest.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types = 1);
+
+namespace IntervalParserTests;
+
+use IntervalParser\TimeInterval;
+use PHPUnit\Framework\TestCase;
+
+# Value object representing a time interval.
+class TimeIntervalTest extends TestCase
+{
+    public function testGetInterval()
+    {
+        $dateInterval = new \DateInterval('P1D');
+        $timeInterval = new TimeInterval($dateInterval, 1, 2, 'foo', 'bar');
+
+        $this->assertInstanceOf(\DateInterval::class, $timeInterval->getInterval());
+        $this->assertSame($dateInterval, $timeInterval->getInterval());
+    }
+
+    public function testGetIntervalOffset()
+    {
+        $timeInterval = new TimeInterval(new \DateInterval('P1D'), 1, 2, 'foo', 'bar');
+
+        $this->assertSame(1, $timeInterval->getIntervalOffset());
+    }
+
+    public function testGetIntervalLength()
+    {
+        $timeInterval = new TimeInterval(new \DateInterval('P1D'), 1, 2, 'foo', 'bar');
+
+        $this->assertSame(2, $timeInterval->getIntervalLength());
+    }
+
+    public function testGetLeadingData()
+    {
+        $timeInterval = new TimeInterval(new \DateInterval('P1D'), 1, 2, 'foo', 'bar');
+
+        $this->assertSame('foo', $timeInterval->getLeadingData());
+    }
+
+    public function testGetLeadingDataReturnsEmptyStringWhenNotSet()
+    {
+        $timeInterval = new TimeInterval(new \DateInterval('P1D'), 1, 2);
+
+        $this->assertSame('', $timeInterval->getLeadingData());
+    }
+
+    public function testGetTrailingData()
+    {
+        $timeInterval = new TimeInterval(new \DateInterval('P1D'), 1, 2, 'foo', 'bar');
+
+        $this->assertSame('bar', $timeInterval->getTrailingData());
+    }
+
+    public function testGetTrailingDataReturnsEmptyStringWhenNotSet()
+    {
+        $timeInterval = new TimeInterval(new \DateInterval('P1D'), 1, 2);
+
+        $this->assertSame('', $timeInterval->getTrailingData());
+    }
+}


### PR DESCRIPTION
This PR is related to #6 

These tests are failing because of some logic error in the `ParserSettings` class:
-  [ ] `testGetWordSeparatorWhenUsingTheDefault` will fail on default value because `getWordSeparatorWhenUsingTheDefault` will return `null` instead of the expect string
- [ ] `testGetWordSeparatorExpressionWhenUsingTheDefault` will fail on default value because `getWordSeparatorWhenUsingTheDefault` will return `null` instead of the expect string
- [ ] Not sure exactly why `testGetWordSeparatorExpressionWhenManuallySet` fails. Might be my fault.

General remarks:
- I am not sure what use `getSeparationType` has
- Currently the replacement methods `ParserSettings::*Expression()` will break when the replacement text contains valid regex. Maybe `preg_quote()` the characters? This still needs tests.
- Some parameters / method names are confusing when looking at just this class. E.g. I have no idea what `$multipleSeparationType` is / means.
- Remove temporary variables in `ParserSettings::*Expression()` and just return the new expression
